### PR TITLE
Timer display

### DIFF
--- a/src/main/java/com/paint/paint/Controller.java
+++ b/src/main/java/com/paint/paint/Controller.java
@@ -22,14 +22,11 @@ import java.util.TimerTask;
 
 //TO-DO LIST
 /*
-    SPRINT 5:
-    - Timer's countdown shall be visible to the user, with view toggleable on/off
-
-
  * KNOWN ISSUES TO FIX:
  *  - Add custom icons for the shapes and tools toolbar
     - Make Undo/Redo less janky. It works, but sometimes does unpredictable things.
     - Somehow fix copy/paste to use the system clipboard.
+    - Fix timer display so that it displays only the current tab's autosave timer
 */
 
 /**
@@ -59,6 +56,10 @@ public class Controller {
     /** canvasSizeSlider is the slider allowing for resizing of the active canvas*/
     @FXML private Slider canvasSizeSlider;
 
+    @FXML private CheckBox timerDispToggle;
+
+    @FXML private Label timerDispBox;
+
     /** tabsOpened is an internal variable that ticks up every time a new canvas is opened*/
     private int tabsOpened = 1;
 
@@ -76,7 +77,7 @@ public class Controller {
      */
     @FXML
     protected void open() throws IOException { //wrapped open() function
-        Display.createNewTab(imageTabs, "untitled" + tabsOpened);
+        Display.createNewTab(imageTabs, "untitled" + tabsOpened, timerDispBox);
         String selectedImg = fileIO.open(imageTabs); //creates string selectedImg and assigns it to a call of fileIO.open()
         Display.showImage(Display.getActiveCanvas(), Display.getActiveCanvas().getGraphicsContext2D(), selectedImg); //passes that string as the path into showImage
         tabsOpened++;
@@ -125,7 +126,7 @@ public class Controller {
      */
     @FXML
     protected void createNewTab() {
-        Display.createNewTab(imageTabs, "untitled" + tabsOpened);
+        Display.createNewTab(imageTabs, "untitled" + tabsOpened, timerDispBox);
         try {Edit.cursorUpdate(Display.getActiveCanvas(), Display.getActiveCanvas().getGraphicsContext2D(), editToggles, colorPicker);}
 
         catch (Exception e) {}
@@ -163,6 +164,9 @@ public class Controller {
 
     @FXML
     protected void redo() { Display.redo(Display.getActiveStack(), Display.getRedoStack()); }
+
+    @FXML
+    protected void timerDisplayUpdate() { Display.timerDisplayUpdate(timerDispToggle, timerDispBox); }
 
     //=====EDIT METHODS=====//
     //Methods from the Edit class. As with above, these methods must be wrapped in a controller method
@@ -223,9 +227,12 @@ public class Controller {
         Menu.widthChoiceConfig(widthChoice);
         Menu.colorPickerConfig(colorPicker);
         Display.firstTab = true;
-        Display.createNewTab(imageTabs, "untitled");
+        Display.createNewTab(imageTabs, "untitled", timerDispBox);
+        Menu.timerDisplayConfig(timerDispBox);
+        /*
         paintTest.getPolygonXSidesTest();
         paintTest.getPolygonYSidesTest();
         paintTest.canvasRescaleTest();
+        */
     }
 }

--- a/src/main/java/com/paint/paint/Display.java
+++ b/src/main/java/com/paint/paint/Display.java
@@ -10,7 +10,6 @@ import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.control.*;
 import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
 import javafx.scene.image.WritableImage;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
@@ -22,7 +21,6 @@ import javafx.stage.Stage;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 
 /**
  * <p> Display.java handles displaying content in the application, including images,
@@ -203,11 +201,9 @@ public class Display {
      * @return newTab, the newly created tab.
      * @since 2.1.1
      */
-    public static imageTab newTab(TabPane tabPane, String name) { //creates a new tab and attaches it to the tabPane
-        imageTab newTab = new imageTab();
-        Label timerLabel = new Label(newTab.autoSave.toString());
+    public static imageTab newTab(TabPane tabPane, String name, Label timerLabel) { //creates a new tab and attaches it to the tabPane
+        imageTab newTab = new imageTab(timerLabel);
         newTab.setText(name);
-        newTab.setContent(timerLabel);
         newTab.setOnCloseRequest(e -> {
             if(getUnsavedChanges() == true) {
                 e.consume();
@@ -288,8 +284,8 @@ public class Display {
      * @param tabName the name that will be given to the tab when it is created.
      * @since 2.1.1
      */
-    public static void createNewTab(TabPane tabPane, String tabName) {
-        imageTab currTab = newTab(tabPane, tabName); //makes a new tab and adds it to the tabpane
+    public static void createNewTab(TabPane tabPane, String tabName, Label timerLabel) {
+        imageTab currTab = newTab(tabPane, tabName, timerLabel); //makes a new tab and adds it to the tabpane
         ScrollPane currScroll = newScroll(currTab); //adds a scrollpane to that tab
         StackPane currStack = newStack(currScroll); //adds a stackpane to that scrollpane
         Canvas currCanvas = newBaseCanvas(currStack); //adds a base canvas to that stackpane (Ho-ro, the rattlin' bog, the bog down in the valley-o....look it up)
@@ -518,6 +514,11 @@ public class Display {
         promptStage.setScene(new Scene(box, 200, 150));
         promptStage.showAndWait();
         return numSides[0];
+    }
+
+    public static void timerDisplayUpdate(CheckBox dispCheck, Label dispBox) {
+        if (dispCheck.isSelected()) { dispBox.setVisible(true); }
+        else dispBox.setVisible(false);
     }
 
 }

--- a/src/main/java/com/paint/paint/Menu.java
+++ b/src/main/java/com/paint/paint/Menu.java
@@ -1,5 +1,6 @@
 package com.paint.paint;
 
+import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.scene.Node;
 import javafx.scene.control.*;
@@ -36,5 +37,9 @@ public class Menu extends Node {
      * @param colorPicker the ColorPicker object to be configured.
      */
     public static void colorPickerConfig (ColorPicker colorPicker) {colorPicker.setValue(Color.BLACK);}
+
+    public static void timerDisplayConfig (Label timerDisplayBox) {
+        timerDisplayBox.setVisible(false);
+    }
 
 }

--- a/src/main/java/com/paint/paint/imageTab.java
+++ b/src/main/java/com/paint/paint/imageTab.java
@@ -2,6 +2,7 @@ package com.paint.paint;
 
 import javafx.application.Platform;
 import javafx.scene.canvas.Canvas;
+import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -18,20 +19,35 @@ public class imageTab extends Tab {
     private ScrollPane scrollPane;
     private StackPane stackPane;
     private Canvas canvas;
-    public Timer autoSave;
-    public imageTab() {
+    private Timer autoSave;
+
+    private int timerVal;
+    public imageTab(Label timerLabel) {
         imageTab newTab = this;
-        autoSave = new Timer();
+        autoSave = new Timer(true);
+        timerVal = 30;
         autoSave.scheduleAtFixedRate( new TimerTask() {
             public void run() {
                 Platform.runLater(() -> {
                     if (lastSavedFile != null) {
-                        try { fileIO.save(stackPane, newTab); }
-                        catch (IOException e) { throw new RuntimeException(e); }
+                        if(timerVal == 0) {
+                            try {
+                                fileIO.save(stackPane, newTab);
+                                timerVal = 30;
+                                timerLabel.setText(Integer.toString(timerVal));
+                            }
+                            catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                        else {
+                            timerVal--;
+                            timerLabel.setText(Integer.toString(timerVal));
+                        }
                     }
                 });
             }
-        },0,30000);  // start immediately, run every 30 seconds
+        },0,1000);  // start immediately, run every 30 seconds
     }
     public void setParentTabPane (TabPane tabPane) { parentTabPane = tabPane; }
     public void setScrollPane (ScrollPane inputScroll) { scrollPane = inputScroll; }
@@ -46,5 +62,9 @@ public class imageTab extends Tab {
     public StackPane getStackPane() { return stackPane; }
 
     public Canvas getCanvas() { return canvas; }
+
+    public Timer getTimer() { return autoSave; }
+
+    public int getTimerVal() { return timerVal; }
     public File getLastSavedFile() { return lastSavedFile; }
 }

--- a/src/main/resources/com/paint/paint/paint.fxml
+++ b/src/main/resources/com/paint/paint/paint.fxml
@@ -122,6 +122,8 @@
          <items>
             <Label prefHeight="17.0" prefWidth="64.0" text="Canvas Size" />
             <Slider fx:id="canvasSizeSlider" max="1.0" min="-1.0" onMouseReleased="#canvasSizeUpdate" />
+            <CheckBox fx:id="timerDispToggle" mnemonicParsing="false" onAction="#timerDisplayUpdate" text="View Autosave Timer" />
+            <Label fx:id="timerDispBox" />
          </items>
       </ToolBar>
    </bottom>


### PR DESCRIPTION
Adds a checkbox and a label to the bottom toolbar. When box is checked, the current autosave timer/timers will be shown to the user. Will tick down and update.

Known issues:
- Timers for as many tabs as are open will all be shown in one label. This means they fight for supremacy and flip back and forth. Should display only the current selected tab's timer.